### PR TITLE
Implement email validity check

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -2,6 +2,7 @@ from image_link import make_image_links
 import pandas as pd
 import asyncio
 import hashlib
+import re
 
 class Parser:
     """
@@ -32,6 +33,10 @@ class Parser:
         self.mail_data_path = mail_data_path
         self.mail_body_path = mail_body_path
         self.report = {}
+        # Email regex is roughly based on RFC 5322 and 1034 of Internet Message Format
+        # it may not allow for some (likely rare) addresses
+        # Source: https://www.w3.org/TR/2012/WD-html-markup-20120329/input.email.html
+        self.EMAIL_REGEX = re.compile(r'^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$')
 
         # 1. Read mail data
         try:
@@ -59,6 +64,10 @@ class Parser:
 
         if "all" in self.departments:
             raise ValueError("Mail Data CSV must not contain a department code named 'all'")
+
+        for email in self.mail_data_df['email']:
+            if re.match(self.EMAIL_REGEX, email) is None:
+                raise ValueError(f"At least one email address: '{email}' does not follow the RFC 5322 and 1034 format")
 
         # 2. Read mail body
         try:


### PR DESCRIPTION
The validity check is mostly based on RFC 5322 and 1034 of Internet Message Format.

[Regex matching](https://www.w3.org/TR/2012/WD-html-markup-20120329/input.email.html) is used.